### PR TITLE
feat: disable container_open_sockets metrics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ container_open_fds{id="/system.slice/docker.service"} 29
 container_open_fds{id="/system.slice/NetworkManager.service"} 21
 container_open_fds{id="/docker/grafana"} 11
 :
-
-# HELP container_open_sockets Number of open sockets
-# TYPE container_open_sockets gauge
-container_open_sockets{id="/system.slice/wpa_supplicant.service"} 16
-container_open_sockets{id="/system.slice/ssh.service"} 4
-container_open_sockets{id="/system.slice/docker.service"} 19
-container_open_sockets{id="/system.slice/NetworkManager.service"} 13
-container_open_sockets{id="/docker/grafana"} 3
-:
 ```
 
 ## options
@@ -64,6 +55,7 @@ container_open_sockets{id="/docker/grafana"} 3
 | arg | description |
 | --- | --- |
 | `--metrics.docker` | enable docker container metrics |
+| `--metrics.open-sockets` | enable container open sockets metrics (disabled by default) |
 | `--cgroup-version` | cgroup version to use (v1, v2) |
 
 ## customize systemd

--- a/main.go
+++ b/main.go
@@ -29,10 +29,11 @@ var (
 	version     string
 	git         string
 
-	address       = flag.String("address", ":48900", "address")
-	cgroupPath    = flag.String("cgroup-path", "/system.slice", "path to cgroup")
-	enableDocker  = flag.Bool("metrics.docker", false, "docker container metrics")
-	cgroupVersion = flag.String("cgroup-version", detectCgroupVersion(), "cgroup version to use (v1, v2)")
+	address           = flag.String("address", ":48900", "address")
+	cgroupPath        = flag.String("cgroup-path", "/system.slice", "path to cgroup")
+	enableDocker      = flag.Bool("metrics.docker", false, "docker container metrics")
+	enableOpenSockets = flag.Bool("metrics.open-sockets", false, "container open sockets metrics")
+	cgroupVersion     = flag.String("cgroup-version", detectCgroupVersion(), "cgroup version to use (v1, v2)")
 )
 
 func main() {
@@ -47,7 +48,7 @@ func main() {
 
 	log.Printf("cgroup version: %s", *cgroupVersion)
 
-	http.HandleFunc("/metrics", exportMetrics(*enableDocker, *cgroupVersion))
+	http.HandleFunc("/metrics", exportMetrics(*enableDocker, *cgroupVersion, *enableOpenSockets))
 
 	server := &http.Server{
 		Addr: *address,
@@ -79,14 +80,16 @@ func processStats(pid int) *ProcessStats {
 		return nil
 	}
 	var socketCount int
-	for _, fd := range fds {
-		fdPath := path.Join(dir, fd.Name())
-		linkName, err := os.Readlink(fdPath)
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(linkName, "socket") {
-			socketCount++
+	if *enableOpenSockets {
+		for _, fd := range fds {
+			fdPath := path.Join(dir, fd.Name())
+			linkName, err := os.Readlink(fdPath)
+			if err != nil {
+				continue
+			}
+			if strings.HasPrefix(linkName, "socket") {
+				socketCount++
+			}
 		}
 	}
 	return &ProcessStats{
@@ -276,7 +279,7 @@ func statsDockerContainers(ctx context.Context) (map[string]dockerStats, error) 
 	return dockerContainers, nil
 }
 
-func exportMetrics(enableDocker bool, cgroupVer string) func(w http.ResponseWriter, r *http.Request) {
+func exportMetrics(enableDocker bool, cgroupVer string, enableOpenSockets bool) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -408,28 +411,30 @@ func exportMetrics(enableDocker bool, cgroupVer string) func(w http.ResponseWrit
 			fmt.Fprintln(w)
 		}
 
-		fmt.Fprintln(w, `# HELP container_open_sockets Number of open sockets
+		if enableOpenSockets {
+			fmt.Fprintln(w, `# HELP container_open_sockets Number of open sockets
 # TYPE container_open_sockets gauge`)
-		for name, stats := range groupsV1 {
-			if stats.Process == nil {
-				continue
+			for name, stats := range groupsV1 {
+				if stats.Process == nil {
+					continue
+				}
+				fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
+				fmt.Fprintln(w)
 			}
-			fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
-			fmt.Fprintln(w)
-		}
-		for name, stats := range groupsV2 {
-			if stats.Process == nil {
-				continue
+			for name, stats := range groupsV2 {
+				if stats.Process == nil {
+					continue
+				}
+				fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
+				fmt.Fprintln(w)
 			}
-			fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
-			fmt.Fprintln(w)
-		}
-		for name, stats := range dockerContainers {
-			if stats.Process == nil {
-				continue
+			for name, stats := range dockerContainers {
+				if stats.Process == nil {
+					continue
+				}
+				fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
+				fmt.Fprintln(w)
 			}
-			fmt.Fprintf(w, `container_open_sockets{id=%s} %d`, strconv.Quote(name), stats.Process.SocketCount)
-			fmt.Fprintln(w)
 		}
 
 		processStats := processStats(os.Getpid())


### PR DESCRIPTION
## What

- Add `--metrics.open-sockets` flag and disable the `container_open_sockets` metrics by default
- Skip socket counting (readlink loop over `/proc/<pid>/fd`) when the flag is disabled; `container_open_fds` is unaffected since it only needs the fd count
- Update README: add the flag to the options table and remove `container_open_sockets` from the example output

## Why

- Part of the vmetrics cost reduction effort: stop sending the unused `container_open_sockets` metrics from robots
- Follow the same opt-in pattern as the existing `--metrics.docker` flag, so users who need the metrics can restore the previous behavior
- Defaulting to disabled means a deb update alone is enough to stop the metrics